### PR TITLE
Redefine ``RssReader.renameSource`` by using `toSpec` and `ofSpec`

### DIFF
--- a/RssReaderFs/RssSource.fs
+++ b/RssReaderFs/RssSource.fs
@@ -77,19 +77,6 @@ module RssSource =
       return (feeds', items)
     }
 
-  let rec rename oldName newName self =
-    match self with
-    | Feed feed ->
-        if feed.Name = oldName
-        then { feed with Name = newName } |> Feed
-        else self
-    | Unread src ->
-        src |> rename oldName newName |> Unread
-    | Union (srcName, srcs) ->
-        let srcName'  = srcName |> replace oldName newName
-        let srcs'     = srcs |> Set.map (rename oldName newName)
-        in Union (srcName', srcs')
-
   let rec toSExpr =
     function
     | Feed (feed: RssFeed) ->
@@ -135,3 +122,15 @@ module RssSource =
     |> Yaml.customTryLoad<RssSourceSpec>
     |> Option.get
     |> ofSpec feedMap
+
+module RssSourceSpec =
+  let rec rename oldName newName self =
+    match self with
+    | Feed (_: Url) ->
+        self
+    | Unread src ->
+        src |> rename oldName newName |> Unread
+    | Union (srcName, srcs) ->
+        let srcName'  = srcName |> replace oldName newName
+        let srcs'     = srcs |> Set.map (rename oldName newName)
+        in Union (srcName', srcs')


### PR DESCRIPTION
## 問題

`RssReader.renameSource` は、「ソースの名前を変更する」というとても単純な関数なのに、実装量がとても多くなってしまっている。
## 原因
- `RssReader` のなかには、 `RssSource` や `RssFeed` への参照が複数ある。
  - 検索のための索引 (Mapのキー) もある。
- 参照先を変更すれば話は早いが、破壊的変更はなるべく避けるという試みをしているので、却下。
- 参照をすべて貼り直し、索引を修正する必要がある。
## 変更

`RssReader` から間接参照と索引を取り除いた形式である `RssReaderSpec` に変換し、それに対して「ソースの名前を変更する」操作を行い、再び `RssReader` を復元する、という手順をとる。
- ちなみに `RssReaderSpec` はシリアライズを効率よく行うのに使うため、実装済みである。
## 結果
- 実装の量はあまり変わらなかった。
- この変更後のほうが効率は悪い。
